### PR TITLE
Static Analysis: Inlining, Compiler & Compile-Time Optimizations

### DIFF
--- a/Ergo/Interpreter/InterpreterScope.cs
+++ b/Ergo/Interpreter/InterpreterScope.cs
@@ -98,6 +98,10 @@ public readonly struct InterpreterScope
     public KnowledgeBase BuildKnowledgeBase()
     {
         var kb = new KnowledgeBase();
+        foreach (var builtIn in VisibleBuiltIns.Values)
+        {
+            kb.AssertZ(new Predicate(builtIn));
+        }
         foreach (var module in VisibleModules)
         {
             foreach (var pred in Modules[module].Program.KnowledgeBase)

--- a/Ergo/Interpreter/Libraries/Expansions/Expansions.cs
+++ b/Ergo/Interpreter/Libraries/Expansions/Expansions.cs
@@ -53,7 +53,7 @@ public class Expansions : Library
             foreach (var match in qse.Solver.KnowledgeBase.GetMatches(qse.Scope.InstantiationContext, topLevelHead, desugar: false)
                 .AsEnumerable().SelectMany(x => x))
             {
-                var pred = Predicate.Substitute(match.Rhs, match.Substitutions);
+                var pred = Predicate.Substitute(match.Predicate, match.Substitutions);
 
                 foreach (var exp in ExpandPredicate(pred, qse.Scope))
                 {

--- a/Ergo/Interpreter/Libraries/Tabling/Tabling.cs
+++ b/Ergo/Interpreter/Libraries/Tabling/Tabling.cs
@@ -87,13 +87,13 @@ public class Tabling : Library
                 foreach (var match in kb.GetMatches(ctx, anon, desugar: false)
                     .AsEnumerable().SelectMany(x => x))
                 {
-                    match.Rhs.Head.GetQualification(out var head);
+                    match.Predicate.Head.GetQualification(out var head);
                     var auxPred = new Predicate(
-                        match.Rhs.Documentation,
-                        match.Rhs.DeclaringModule,
+                        match.Predicate.Documentation,
+                        match.Predicate.DeclaringModule,
                         head.WithFunctor(auxFunctor),
-                        match.Rhs.Body,
-                        match.Rhs.IsDynamic,
+                        match.Predicate.Body,
+                        match.Predicate.IsDynamic,
                         false
                     );
                     if (!kb.Retract(head))

--- a/Ergo/Lang/Ast/Predicates/Predicate.cs
+++ b/Ergo/Lang/Ast/Predicates/Predicate.cs
@@ -303,15 +303,13 @@ public readonly struct Predicate : IExplainable
     {
         if (IsBuiltIn || Head.IsQualified)
             return this;
-        return new(Documentation, DeclaringModule, Head.Qualified(DeclaringModule), Body, IsDynamic, IsExported, IsTailRecursive);
+        return WithHead(Head.Qualified(DeclaringModule));
     }
     public Predicate Unqualified()
     {
-        if (IsBuiltIn)
-            throw new NotSupportedException();
         if (!Head.GetQualification(out var head).TryGetValue(out var _))
             return this;
-        return new(Documentation, DeclaringModule, head, Body, IsDynamic, IsExported, IsTailRecursive);
+        return WithHead(head);
     }
 
     public static bool FromCanonical(ITerm term, Atom defaultModule, out Predicate pred)

--- a/Ergo/Lang/Ast/Programs/Query.cs
+++ b/Ergo/Lang/Ast/Programs/Query.cs
@@ -8,4 +8,5 @@ public class Query
     public readonly NTuple Goals;
     public Query(NTuple goals) => Goals = goals;
     public Query(params ITerm[] goals) => Goals = new(goals, default);
+    public Query(ImmutableArray<ITerm> goals) => Goals = new(goals, default);
 }

--- a/Ergo/Lang/Ast/_Shared/Signature.cs
+++ b/Ergo/Lang/Ast/_Shared/Signature.cs
@@ -54,7 +54,8 @@ public readonly struct Signature
 
     public static bool operator !=(Signature left, Signature right) => !(left == right);
 
-    public override int GetHashCode() => HashCode.Combine(Functor.GetHashCode(), Arity.GetHashCode(), Module.GetHashCode());
+    public override int GetHashCode() => HashCode.Combine(Functor.GetHashCode(), Arity.GetHashCode(), Module.GetHashCode(),
+        1 - Arity.TryGetValue(out _).GetHashCode(), 1 - Module.TryGetValue(out _).GetHashCode());
 
     public static bool FromCanonical(ITerm term, out Signature sig)
     {

--- a/Ergo/Lang/Compiler/ExecutionGraph.cs
+++ b/Ergo/Lang/Compiler/ExecutionGraph.cs
@@ -1,0 +1,114 @@
+﻿using Ergo.Solver.BuiltIns;
+
+public class ExecutionNode { }
+
+/// <summary>
+/// Represents a cut, which prevents further backtracking.
+/// </summary>
+public class CutNode : ExecutionNode { }
+
+/// <summary>
+/// Represents a built-in node, similar to a goal node but more primitive and closely integrated with C#.
+/// </summary>
+public class BuiltInNode : ExecutionNode
+{
+    public SolverBuiltIn BuiltIn { get; }
+}
+
+/// <summary>
+/// Represents an individual qualified goal. It might still be made up of multiple clauses, but only from one module's definition.
+/// Ambiguous goals are represented as BranchNodes containing all possible qualifications of each goal.
+/// </summary>
+public class GoalNode : ExecutionNode
+{
+    public GoalNode(DependencyGraphNode goal) => Goal = goal;
+
+    public DependencyGraphNode Goal { get; }
+}
+
+public class IfThenNode : ExecutionNode
+{
+    public IfThenNode(ExecutionNode condition, ExecutionNode trueBranch)
+    {
+        Condition = condition;
+        TrueBranch = trueBranch;
+    }
+
+    public ExecutionNode Condition { get; }
+    public ExecutionNode TrueBranch { get; }
+}
+/// <summary>
+/// Represents an if-then-else statement.
+/// </summary>
+public class IfThenElseNode : ExecutionNode
+{
+    public IfThenElseNode(ExecutionNode condition, ExecutionNode trueBranch, ExecutionNode falseBranch)
+    {
+        Condition = condition;
+        TrueBranch = trueBranch;
+        FalseBranch = falseBranch;
+    }
+
+    public ExecutionNode Condition { get; }
+    public ExecutionNode TrueBranch { get; }
+    public ExecutionNode FalseBranch { get; }
+}
+
+/// <summary>
+/// Represents a logical disjunction.
+/// </summary>
+public class BranchNode : ExecutionNode
+{
+    public BranchNode(ExecutionNode left, ExecutionNode right)
+    {
+        Left = left;
+        Right = right;
+    }
+
+    public ExecutionNode Left { get; }
+    public ExecutionNode Right { get; }
+    public bool LeftTried { get; set; } = false;
+    public bool RightTried { get; set; } = false;
+}
+
+/// <summary>
+/// Represents a logical conjunction.
+/// </summary>
+public class SequenceNode : ExecutionNode
+{
+    public SequenceNode(List<ExecutionNode> nodes) => Nodes = nodes;
+
+    public List<ExecutionNode> Nodes { get; }
+}
+
+public static class ExecutionGraphExtensions
+{
+    public static IEnumerable<ExecutionNode> ToExecutionGraph(this Predicate clause, DependencyGraph graph)
+    {
+        foreach (var goal in clause.Body.Contents)
+        {
+        }
+        return null;
+        static ExecutionNode ToExecutionNode(ITerm goal)
+        {
+            if (goal is NTuple tup)
+                return new SequenceNode(tup.Contents.Select(x => ToExecutionNode(x)).ToList());
+            if (goal is Complex { Functor: var functor, Arity: var arity, Arguments: var args })
+            {
+                if (arity == 2 && WellKnown.Operators.Disjunction.Synonyms.Contains(functor))
+                    return new BranchNode(ToExecutionNode(args[0]), ToExecutionNode(args[1]));
+                if (arity == 2 && WellKnown.Operators.If.Synonyms.Contains(functor))
+                {
+                    if (args[1] is Complex { Functor: var functor1, Arity: var arity1, Arguments: var args1 }
+                        && arity1 == 2 && WellKnown.Operators.Disjunction.Synonyms.Contains(functor1))
+                    {
+                        return new IfThenElseNode(ToExecutionNode(args[0]), ToExecutionNode(args1[0]), ToExecutionNode(args1[1]));
+                    }
+                    return new IfThenNode(ToExecutionNode(args[0]), ToExecutionNode(args[1]));
+                }
+            }
+            // If 'goal' isn't any other type of node, then it's a proper goal and we need to resolve it in the context of 'clause'.
+            return null;
+        }
+    }
+}

--- a/Ergo/Lang/KnowledgeBase/KnowledgeBase.Match.cs
+++ b/Ergo/Lang/KnowledgeBase/KnowledgeBase.Match.cs
@@ -2,14 +2,14 @@
 
 public readonly struct KBMatch
 {
-    public readonly ITerm Lhs;
-    public readonly Predicate Rhs;
+    public readonly ITerm Goal;
+    public readonly Predicate Predicate;
     public readonly SubstitutionMap Substitutions;
 
     public KBMatch(ITerm lhs, Predicate rhs, SubstitutionMap substitutions)
     {
-        Lhs = lhs;
-        Rhs = rhs;
+        Goal = lhs;
+        Predicate = rhs;
         Substitutions = substitutions;
     }
 }

--- a/Ergo/Lang/KnowledgeBase/KnowledgeBase.cs
+++ b/Ergo/Lang/KnowledgeBase/KnowledgeBase.cs
@@ -1,18 +1,15 @@
-﻿using System.Collections;
+﻿using Ergo.Solver.BuiltIns;
+using System.Collections;
 using System.Collections.Specialized;
 
 namespace Ergo.Lang;
 
 public partial class KnowledgeBase : IReadOnlyCollection<Predicate>
 {
-    protected readonly OrderedDictionary Predicates;
+    protected readonly Dictionary<Signature, SolverBuiltIn> BuiltIns = new();
+    protected readonly OrderedDictionary Predicates = new();
 
     public int Count => Predicates.Values.Cast<List<Predicate>>().Sum(l => l.Count);
-
-    public KnowledgeBase()
-    {
-        Predicates = new OrderedDictionary();
-    }
 
     public void Clear() => Predicates.Clear();
 

--- a/Ergo/Lang/_Extensions/LanguageExtensions.cs
+++ b/Ergo/Lang/_Extensions/LanguageExtensions.cs
@@ -75,7 +75,8 @@ public static class LanguageExtensions
 
     public static Maybe<SubstitutionMap> Unify(this Predicate predicate, ITerm head)
     {
-        predicate.Head.GetQualification(out var qv);
+        var h = predicate.Head;
+        h.GetQualification(out var qv);
         head.GetQualification(out var hv);
         return Unify(qv, hv);
     }

--- a/Ergo/Solver/Async/Pull.cs
+++ b/Ergo/Solver/Async/Pull.cs
@@ -7,7 +7,7 @@ public sealed class RunTask : SolverBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] args)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> args)
     {
         var any = false;
         foreach (var sol in context.Solver.Solve(new Query(args[0]), scope))

--- a/Ergo/Solver/Built-Ins/CSharp/Pull.cs
+++ b/Ergo/Solver/Built-Ins/CSharp/Pull.cs
@@ -15,13 +15,13 @@ public sealed class Pull : SolverBuiltIn
             if (item.Rhs.Unify(args[0]).TryGetValue(out var subs))
             {
                 any = true;
-                yield return new(WellKnown.Literals.True, subs);
+                yield return True(subs);
             }
         }
 
         if (!any)
         {
-            yield return new(WellKnown.Literals.False);
+            yield return False();
         }
     }
 }

--- a/Ergo/Solver/Built-Ins/CSharp/Pull.cs
+++ b/Ergo/Solver/Built-Ins/CSharp/Pull.cs
@@ -7,12 +7,12 @@ public sealed class Pull : SolverBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] args)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> args)
     {
         var any = false;
         foreach (var item in context.Solver.GetDataSourceMatches(args[0]).ToEnumerable())
         {
-            if (item.Rhs.Unify(args[0]).TryGetValue(out var subs))
+            if (item.Predicate.Unify(args[0]).TryGetValue(out var subs))
             {
                 any = true;
                 yield return True(subs);

--- a/Ergo/Solver/Built-Ins/CSharp/Push.cs
+++ b/Ergo/Solver/Built-Ins/CSharp/Push.cs
@@ -9,7 +9,7 @@ public sealed class Push : SolverBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] args)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> args)
     {
         if (!args[0].IsGround)
         {

--- a/Ergo/Solver/Built-Ins/CSharp/Push.cs
+++ b/Ergo/Solver/Built-Ins/CSharp/Push.cs
@@ -14,11 +14,11 @@ public sealed class Push : SolverBuiltIn
         if (!args[0].IsGround)
         {
             scope.Throw(SolverError.TermNotSufficientlyInstantiated, args[0].Explain(true));
-            yield return new(WellKnown.Literals.False);
+            yield return False();
             yield break;
         }
 
         context.Solver.PushData(args[0]);
-        yield return new(WellKnown.Literals.True);
+        yield return True();
     }
 }

--- a/Ergo/Solver/Built-Ins/Dict/DictKeyValue.cs
+++ b/Ergo/Solver/Built-Ins/Dict/DictKeyValue.cs
@@ -9,7 +9,7 @@ public sealed class DictKeyValue : SolverBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] args)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> args)
     {
         if (args[0] is Variable)
         {

--- a/Ergo/Solver/Built-Ins/Dict/With.cs
+++ b/Ergo/Solver/Built-Ins/Dict/With.cs
@@ -8,7 +8,7 @@ public sealed class With : SolverBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] args)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> args)
     {
         if (args[0] is Dict a)
         {

--- a/Ergo/Solver/Built-Ins/IO/GetChar.cs
+++ b/Ergo/Solver/Built-Ins/IO/GetChar.cs
@@ -7,7 +7,7 @@ public sealed class GetChar : SolverBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] arguments)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> arguments)
     {
         int value;
         do

--- a/Ergo/Solver/Built-Ins/IO/GetSingleChar.cs
+++ b/Ergo/Solver/Built-Ins/IO/GetSingleChar.cs
@@ -6,7 +6,7 @@ public sealed class GetSingleChar : SolverBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] arguments)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> arguments)
     {
         int value = context.Solver.In.Read();
         ITerm charTerm = value != -1 ? new Atom((char)value) : new Atom("end_of_file");

--- a/Ergo/Solver/Built-Ins/IO/PeekChar.cs
+++ b/Ergo/Solver/Built-Ins/IO/PeekChar.cs
@@ -7,7 +7,7 @@ public sealed class PeekChar : SolverBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] arguments)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> arguments)
     {
         int value = context.Solver.In.Peek();
         ITerm charTerm = value != -1 ? new Atom((char)value) : new Atom("end_of_file");

--- a/Ergo/Solver/Built-Ins/IO/Read.cs
+++ b/Ergo/Solver/Built-Ins/IO/Read.cs
@@ -9,7 +9,7 @@ public sealed class Read : SolverBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] arguments)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> arguments)
     {
         var sb = new StringBuilder();
 

--- a/Ergo/Solver/Built-Ins/IO/ReadLine.cs
+++ b/Ergo/Solver/Built-Ins/IO/ReadLine.cs
@@ -9,7 +9,7 @@ public sealed class ReadLine : SolverBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] arguments)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> arguments)
     {
         var builder = new StringBuilder();
         int value;

--- a/Ergo/Solver/Built-Ins/Lambda/Lambda.cs
+++ b/Ergo/Solver/Built-Ins/Lambda/Lambda.cs
@@ -8,7 +8,7 @@ public sealed class Lambda : SolverBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] args)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> args)
     {
         if (args.Length < 2)
         {
@@ -45,9 +45,8 @@ public sealed class Lambda : SolverBuiltIn
             lambda = lambda.Substitute(newSubs);
         }
 
-        var extraArgs = rest.Length > list.Contents.Length ? rest[list.Contents.Length..] : Array.Empty<ITerm>();
-
-        foreach (var eval in new Call().Apply(context, scope, new[] { lambda }.Concat(extraArgs).ToArray()))
+        var extraArgs = rest.Length > list.Contents.Length ? rest[list.Contents.Length..] : ImmutableArray<ITerm>.Empty;
+        foreach (var eval in new Call().Apply(context, scope, new[] { lambda }.Concat(extraArgs).ToImmutableArray()))
         {
             yield return eval;
         }

--- a/Ergo/Solver/Built-Ins/List/ListSet.cs
+++ b/Ergo/Solver/Built-Ins/List/ListSet.cs
@@ -8,7 +8,7 @@ public sealed class ListSet : SolverBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] args)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> args)
     {
         if (args[0] is List list)
         {

--- a/Ergo/Solver/Built-Ins/List/Sort.cs
+++ b/Ergo/Solver/Built-Ins/List/Sort.cs
@@ -8,7 +8,7 @@ public sealed class Sort : SolverBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] args)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> args)
     {
         if (args[0] is List list)
         {

--- a/Ergo/Solver/Built-Ins/List/_Shared/NthBase.cs
+++ b/Ergo/Solver/Built-Ins/List/_Shared/NthBase.cs
@@ -7,7 +7,7 @@ public abstract class NthBase : SolverBuiltIn
     public NthBase(int offset)
         : base("", new($"nth{offset}"), Maybe<int>.Some(3), WellKnown.Modules.List) => Offset = offset;
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] args)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> args)
     {
         if (args[0].Matches<int>(out var index))
         {

--- a/Ergo/Solver/Built-Ins/List/_Shared/NthBase.cs
+++ b/Ergo/Solver/Built-Ins/List/_Shared/NthBase.cs
@@ -53,7 +53,7 @@ public abstract class NthBase : SolverBuiltIn
             }
             else if (!args[1].IsGround)
             {
-                yield return new Evaluation(WellKnown.Literals.True);
+                yield return True();
                 yield break;
             }
         }

--- a/Ergo/Solver/Built-Ins/Math/Eval.cs
+++ b/Ergo/Solver/Built-Ins/Math/Eval.cs
@@ -9,18 +9,12 @@ public sealed class Eval : MathBuiltIn
 
     public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> arguments)
     {
-        var eval = scope.InterpreterScope.ExceptionHandler.TryGet(() => new Atom(Evaluate(context.Solver, scope, arguments[0])));
-        if (!eval.TryGetValue(out var atom))
-        {
-            yield return False();
-            yield break;
-        }
-        if (arguments[1].Unify(atom).TryGetValue(out var subs))
+        var eval = scope.InterpreterScope.ExceptionHandler.TryGet(() => new Atom(Evaluate(context.Solver, scope, arguments[1])));
+        if (eval.TryGetValue(out var result) && LanguageExtensions.Unify(arguments[0], result).TryGetValue(out var subs))
         {
             yield return True(subs);
             yield break;
         }
         yield return False();
-        yield break;
     }
 }

--- a/Ergo/Solver/Built-Ins/Math/Eval.cs
+++ b/Ergo/Solver/Built-Ins/Math/Eval.cs
@@ -7,7 +7,7 @@ public sealed class Eval : MathBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] arguments)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> arguments)
     {
         var eval = scope.InterpreterScope.ExceptionHandler.TryGet(() => new Atom(Evaluate(context.Solver, scope, arguments[0])));
         if (!eval.TryGetValue(out var atom))

--- a/Ergo/Solver/Built-Ins/Math/Eval.cs
+++ b/Ergo/Solver/Built-Ins/Math/Eval.cs
@@ -3,13 +3,24 @@
 public sealed class Eval : MathBuiltIn
 {
     public Eval()
-        : base("", new("eval"), Maybe<int>.Some(1))
+        : base("", new("eval"), Maybe<int>.Some(2))
     {
     }
 
     public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] arguments)
     {
-        var eval = scope.InterpreterScope.ExceptionHandler.TryGet(() => new Evaluation(new Atom(Evaluate(context.Solver, scope, arguments[0]))));
-        yield return eval.GetOr(False());
+        var eval = scope.InterpreterScope.ExceptionHandler.TryGet(() => new Atom(Evaluate(context.Solver, scope, arguments[0])));
+        if (!eval.TryGetValue(out var atom))
+        {
+            yield return False();
+            yield break;
+        }
+        if (arguments[1].Unify(atom).TryGetValue(out var subs))
+        {
+            yield return True(subs);
+            yield break;
+        }
+        yield return False();
+        yield break;
     }
 }

--- a/Ergo/Solver/Built-Ins/Math/Is.cs
+++ b/Ergo/Solver/Built-Ins/Math/Is.cs
@@ -7,7 +7,7 @@ public sealed class Is : MathBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] arguments)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> arguments)
     {
         var eval = scope.InterpreterScope.ExceptionHandler.TryGet(() => new Atom(Evaluate(context.Solver, scope, arguments[1])));
         if (eval.TryGetValue(out var result) && LanguageExtensions.Unify(arguments[0], result).TryGetValue(out var subs))

--- a/Ergo/Solver/Built-Ins/Math/NumberString.cs
+++ b/Ergo/Solver/Built-Ins/Math/NumberString.cs
@@ -9,7 +9,7 @@ public sealed class NumberString : SolverBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext solver, SolverScope scope, ITerm[] arguments)
+    public override IEnumerable<Evaluation> Apply(SolverContext solver, SolverScope scope, ImmutableArray<ITerm> arguments)
     {
         var (str, num) = (arguments[1], arguments[0]);
         if (!str.IsGround && !num.IsGround)

--- a/Ergo/Solver/Built-Ins/Meta/BagOf.cs
+++ b/Ergo/Solver/Built-Ins/Meta/BagOf.cs
@@ -15,17 +15,17 @@ public sealed class BagOf : SolutionAggregationBuiltIn
             if (!LanguageExtensions.Unify(ListVars, ArgVars).TryGetValue(out var listSubs)
             || !LanguageExtensions.Unify(args[2], ListTemplate).TryGetValue(out var instSubs))
             {
-                yield return new(WellKnown.Literals.False);
+                yield return False();
                 yield break;
             }
 
-            yield return new(WellKnown.Literals.True, SubstitutionMap.MergeRef(instSubs, listSubs));
+            yield return True(SubstitutionMap.MergeRef(instSubs, listSubs));
             any = true;
         }
 
         if (!any)
         {
-            yield return new(WellKnown.Literals.False);
+            yield return False();
         }
     }
 }

--- a/Ergo/Solver/Built-Ins/Meta/BagOf.cs
+++ b/Ergo/Solver/Built-Ins/Meta/BagOf.cs
@@ -7,7 +7,7 @@ public sealed class BagOf : SolutionAggregationBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] args)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> args)
     {
         var any = false;
         foreach (var (ArgVars, ListTemplate, ListVars) in AggregateSolutions(context.Solver, scope, args))

--- a/Ergo/Solver/Built-Ins/Meta/Call.cs
+++ b/Ergo/Solver/Built-Ins/Meta/Call.cs
@@ -8,7 +8,7 @@ public sealed class Call : SolverBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] args)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> args)
     {
         scope = scope.WithDepth(scope.Depth + 1)
             .WithCaller(scope.Callee)

--- a/Ergo/Solver/Built-Ins/Meta/FindAll.cs
+++ b/Ergo/Solver/Built-Ins/Meta/FindAll.cs
@@ -24,7 +24,7 @@ public sealed class FindAll : SolverBuiltIn
         {
             if (args[2].IsGround && args[2].Equals(WellKnown.Literals.EmptyList))
             {
-                yield return new Evaluation(WellKnown.Literals.True);
+                yield return new Evaluation(true);
             }
             else if (!args[2].IsGround)
             {
@@ -40,7 +40,7 @@ public sealed class FindAll : SolverBuiltIn
             var list = new List(ImmutableArray.CreateRange(solutions.Select(s => args[0].Substitute(s.Substitutions))), default, default);
             if (args[2].IsGround && args[2].Equals(list))
             {
-                yield return new Evaluation(WellKnown.Literals.True);
+                yield return new Evaluation(true);
             }
             else if (!args[2].IsGround)
             {

--- a/Ergo/Solver/Built-Ins/Meta/FindAll.cs
+++ b/Ergo/Solver/Built-Ins/Meta/FindAll.cs
@@ -8,7 +8,7 @@ public sealed class FindAll : SolverBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] args)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> args)
     {
         scope = scope.WithDepth(scope.Depth + 1)
             .WithCaller(scope.Callee)

--- a/Ergo/Solver/Built-Ins/Meta/SetOf.cs
+++ b/Ergo/Solver/Built-Ins/Meta/SetOf.cs
@@ -19,17 +19,17 @@ public sealed class SetOf : SolutionAggregationBuiltIn
             if (!LanguageExtensions.Unify(setVars, argSet).TryGetValue(out var listSubs)
             || !LanguageExtensions.Unify(args[2], setTemplate).TryGetValue(out var instSubs))
             {
-                yield return new(WellKnown.Literals.False);
+                yield return False();
                 yield break;
             }
 
-            yield return new(WellKnown.Literals.True, SubstitutionMap.MergeRef(listSubs, instSubs));
+            yield return True(SubstitutionMap.MergeRef(listSubs, instSubs));
             any = true;
         }
 
         if (!any)
         {
-            yield return new(WellKnown.Literals.False);
+            yield return False();
         }
     }
 }

--- a/Ergo/Solver/Built-Ins/Meta/SetOf.cs
+++ b/Ergo/Solver/Built-Ins/Meta/SetOf.cs
@@ -7,7 +7,7 @@ public sealed class SetOf : SolutionAggregationBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] args)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> args)
     {
         var any = false;
         foreach (var (ArgVars, ListTemplate, ListVars) in AggregateSolutions(context.Solver, scope, args))

--- a/Ergo/Solver/Built-Ins/Meta/SetupCallCleanup.cs
+++ b/Ergo/Solver/Built-Ins/Meta/SetupCallCleanup.cs
@@ -7,9 +7,9 @@ public sealed class SetupCallCleanup : SolverBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] args)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> args)
     {
-        var once = new Call().Apply(context, scope, new[] { args[0] }).Select(x => Maybe.Some(x)).FirstOrDefault();
+        var once = new Call().Apply(context, scope, ImmutableArray.Create(args[0])).Select(x => Maybe.Some(x)).FirstOrDefault();
         if (!once.TryGetValue(out var sol) || !sol.Result)
         {
             yield return False();
@@ -17,7 +17,7 @@ public sealed class SetupCallCleanup : SolverBuiltIn
         }
 
         var any = false;
-        foreach (var sol1 in new Call().Apply(context, scope, new[] { args[1] }))
+        foreach (var sol1 in new Call().Apply(context, scope, ImmutableArray.Create(args[1])))
         {
             if (!sol1.Result)
             {
@@ -29,7 +29,7 @@ public sealed class SetupCallCleanup : SolverBuiltIn
             any = true;
         }
 
-        _ = new Call().Apply(context, scope, new[] { args[2] }).FirstOrDefault();
+        _ = new Call().Apply(context, scope, ImmutableArray.Create(args[2])).FirstOrDefault();
         if (!any)
         {
             yield return False();

--- a/Ergo/Solver/Built-Ins/Meta/SetupCallCleanup.cs
+++ b/Ergo/Solver/Built-Ins/Meta/SetupCallCleanup.cs
@@ -9,30 +9,30 @@ public sealed class SetupCallCleanup : SolverBuiltIn
 
     public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] args)
     {
-        var once = new Call().Apply(context, scope, new[] { args[0] }).FirstOrDefault();
-        if (once.Equals(default(Evaluation)) || once.Result.Equals(WellKnown.Literals.False))
+        var once = new Call().Apply(context, scope, new[] { args[0] }).Select(x => Maybe.Some(x)).FirstOrDefault();
+        if (!once.TryGetValue(out var sol) || !sol.Result)
         {
-            yield return new(WellKnown.Literals.False);
+            yield return False();
             yield break;
         }
 
         var any = false;
-        foreach (var sol in new Call().Apply(context, scope, new[] { args[1] }))
+        foreach (var sol1 in new Call().Apply(context, scope, new[] { args[1] }))
         {
-            if (sol.Result.Equals(WellKnown.Literals.False))
+            if (!sol1.Result)
             {
-                yield return new(WellKnown.Literals.False);
+                yield return False();
                 yield break;
             }
 
-            yield return new(WellKnown.Literals.True, sol.Substitutions);
+            yield return True(sol1.Substitutions);
             any = true;
         }
 
-        new Call().Apply(context, scope, new[] { args[2] }).FirstOrDefault();
+        _ = new Call().Apply(context, scope, new[] { args[2] }).FirstOrDefault();
         if (!any)
         {
-            yield return new(WellKnown.Literals.False);
+            yield return False();
             yield break;
         }
     }

--- a/Ergo/Solver/Built-Ins/Prologue/AssertA.cs
+++ b/Ergo/Solver/Built-Ins/Prologue/AssertA.cs
@@ -11,11 +11,11 @@ public sealed class AssertA : DynamicPredicateBuiltIn
     {
         if (Assert(context.Solver, scope, arguments[0], z: false))
         {
-            yield return new(WellKnown.Literals.True);
+            yield return True();
         }
         else
         {
-            yield return new(WellKnown.Literals.False);
+            yield return False();
         }
     }
 }

--- a/Ergo/Solver/Built-Ins/Prologue/AssertA.cs
+++ b/Ergo/Solver/Built-Ins/Prologue/AssertA.cs
@@ -7,7 +7,7 @@ public sealed class AssertA : DynamicPredicateBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] arguments)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> arguments)
     {
         if (Assert(context.Solver, scope, arguments[0], z: false))
         {

--- a/Ergo/Solver/Built-Ins/Prologue/AssertZ.cs
+++ b/Ergo/Solver/Built-Ins/Prologue/AssertZ.cs
@@ -7,7 +7,7 @@ public sealed class AssertZ : DynamicPredicateBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] arguments)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> arguments)
     {
         if (Assert(context.Solver, scope, arguments[0], z: true))
         {

--- a/Ergo/Solver/Built-Ins/Prologue/AssertZ.cs
+++ b/Ergo/Solver/Built-Ins/Prologue/AssertZ.cs
@@ -11,11 +11,11 @@ public sealed class AssertZ : DynamicPredicateBuiltIn
     {
         if (Assert(context.Solver, scope, arguments[0], z: true))
         {
-            yield return new(WellKnown.Literals.True);
+            yield return True();
         }
         else
         {
-            yield return new(WellKnown.Literals.False);
+            yield return False();
         }
     }
 }

--- a/Ergo/Solver/Built-Ins/Prologue/Cut.cs
+++ b/Ergo/Solver/Built-Ins/Prologue/Cut.cs
@@ -9,6 +9,6 @@ public sealed class Cut : SolverBuiltIn
 
     public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] arguments)
     {
-        yield return new(WellKnown.Literals.True);
+        yield return True();
     }
 }

--- a/Ergo/Solver/Built-Ins/Prologue/Cut.cs
+++ b/Ergo/Solver/Built-Ins/Prologue/Cut.cs
@@ -7,8 +7,9 @@ public sealed class Cut : SolverBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] arguments)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> arguments)
     {
         yield return True();
+        context.Cut();
     }
 }

--- a/Ergo/Solver/Built-Ins/Prologue/Not.cs
+++ b/Ergo/Solver/Built-Ins/Prologue/Not.cs
@@ -13,11 +13,11 @@ public sealed class Not : SolverBuiltIn
         var solutions = context.Solver.Solve(new Query(arguments.Single()), scope);
         if (solutions.Any())
         {
-            yield return new(WellKnown.Literals.False);
+            yield return False();
         }
         else
         {
-            yield return new(WellKnown.Literals.True);
+            yield return True();
         }
     }
 }

--- a/Ergo/Solver/Built-Ins/Prologue/Not.cs
+++ b/Ergo/Solver/Built-Ins/Prologue/Not.cs
@@ -8,7 +8,7 @@ public sealed class Not : SolverBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] arguments)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> arguments)
     {
         var solutions = context.Solver.Solve(new Query(arguments.Single()), scope);
         if (solutions.Any())

--- a/Ergo/Solver/Built-Ins/Prologue/Retract.cs
+++ b/Ergo/Solver/Built-Ins/Prologue/Retract.cs
@@ -7,7 +7,7 @@ public sealed class Retract : DynamicPredicateBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] arguments)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> arguments)
     {
         var any = false;
         while (Retract(context.Solver, scope, arguments[0], all: false))

--- a/Ergo/Solver/Built-Ins/Prologue/Retract.cs
+++ b/Ergo/Solver/Built-Ins/Prologue/Retract.cs
@@ -12,13 +12,13 @@ public sealed class Retract : DynamicPredicateBuiltIn
         var any = false;
         while (Retract(context.Solver, scope, arguments[0], all: false))
         {
-            yield return new(WellKnown.Literals.True);
+            yield return True();
             any = true;
         }
 
         if (!any)
         {
-            yield return new(WellKnown.Literals.False);
+            yield return False();
         }
     }
 }

--- a/Ergo/Solver/Built-Ins/Prologue/RetractAll.cs
+++ b/Ergo/Solver/Built-Ins/Prologue/RetractAll.cs
@@ -7,7 +7,7 @@ public sealed class RetractAll : DynamicPredicateBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] arguments)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> arguments)
     {
         if (Retract(context.Solver, scope, arguments[0], all: true)) yield return True();
         else yield return False();

--- a/Ergo/Solver/Built-Ins/Prologue/RetractAll.cs
+++ b/Ergo/Solver/Built-Ins/Prologue/RetractAll.cs
@@ -9,7 +9,7 @@ public sealed class RetractAll : DynamicPredicateBuiltIn
 
     public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] arguments)
     {
-        if (Retract(context.Solver, scope, arguments[0], all: true)) yield return new(WellKnown.Literals.True);
-        else yield return new(WellKnown.Literals.False);
+        if (Retract(context.Solver, scope, arguments[0], all: true)) yield return True();
+        else yield return False();
     }
 }

--- a/Ergo/Solver/Built-Ins/Prologue/Unifiable.cs
+++ b/Ergo/Solver/Built-Ins/Prologue/Unifiable.cs
@@ -7,7 +7,7 @@ public sealed class Unifiable : SolverBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] arguments)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> arguments)
     {
         if (LanguageExtensions.Unify(arguments[0], arguments[1]).TryGetValue(out var subs))
         {

--- a/Ergo/Solver/Built-Ins/Prologue/Unifiable.cs
+++ b/Ergo/Solver/Built-Ins/Prologue/Unifiable.cs
@@ -16,11 +16,11 @@ public sealed class Unifiable : SolverBuiltIn
             List list = new(ImmutableArray.CreateRange(equations), default, default);
             if (new Substitution(arguments[2], list).Unify().TryGetValue(out subs))
             {
-                yield return new(WellKnown.Literals.True, subs);
+                yield return True(subs);
                 yield break;
             }
         }
 
-        yield return new(WellKnown.Literals.False);
+        yield return False();
     }
 }

--- a/Ergo/Solver/Built-Ins/Prologue/Unify.cs
+++ b/Ergo/Solver/Built-Ins/Prologue/Unify.cs
@@ -9,13 +9,9 @@ public sealed class Unify : SolverBuiltIn
 
     public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] arguments)
     {
-        if (LanguageExtensions.Unify(arguments[0], arguments[1]).TryGetValue(out var subs))
-        {
-            yield return new(WellKnown.Literals.True, subs);
-        }
+        if (arguments[0].Unify(arguments[1]).TryGetValue(out var subs))
+            yield return True(subs);
         else
-        {
-            yield return new(WellKnown.Literals.False);
-        }
+            yield return False();
     }
 }

--- a/Ergo/Solver/Built-Ins/Prologue/Unify.cs
+++ b/Ergo/Solver/Built-Ins/Prologue/Unify.cs
@@ -7,7 +7,7 @@ public sealed class Unify : SolverBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] arguments)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> arguments)
     {
         if (arguments[0].Unify(arguments[1]).TryGetValue(out var subs))
             yield return True(subs);

--- a/Ergo/Solver/Built-Ins/Reflection/AnonymousComplex.cs
+++ b/Ergo/Solver/Built-Ins/Reflection/AnonymousComplex.cs
@@ -7,7 +7,7 @@ public sealed class AnonymousComplex : SolverBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] args)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> args)
     {
         if (!args[1].Matches<int>(out var arity))
         {

--- a/Ergo/Solver/Built-Ins/Reflection/CommaList.cs
+++ b/Ergo/Solver/Built-Ins/Reflection/CommaList.cs
@@ -8,7 +8,7 @@ public sealed class CommaToList : SolverBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] arguments)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> arguments)
     {
         var (commaArg, listArg) = (arguments[0], arguments[1]);
         if (listArg is not Variable)

--- a/Ergo/Solver/Built-Ins/Reflection/CommaList.cs
+++ b/Ergo/Solver/Built-Ins/Reflection/CommaList.cs
@@ -22,11 +22,11 @@ public sealed class CommaToList : SolverBuiltIn
             var comma = new NTuple(list.Contents, default);
             if (!LanguageExtensions.Unify(commaArg, comma).TryGetValue(out var subs))
             {
-                yield return new(WellKnown.Literals.False);
+                yield return False();
                 yield break;
             }
 
-            yield return new(WellKnown.Literals.True, subs);
+            yield return True(subs);
             yield break;
         }
 
@@ -41,11 +41,11 @@ public sealed class CommaToList : SolverBuiltIn
             var list = new List(comma.Contents, default, default);
             if (!LanguageExtensions.Unify(listArg, list).TryGetValue(out var subs))
             {
-                yield return new(WellKnown.Literals.False);
+                yield return False();
                 yield break;
             }
 
-            yield return new(WellKnown.Literals.True, subs);
+            yield return True(subs);
             yield break;
         }
 

--- a/Ergo/Solver/Built-Ins/Reflection/Compare.cs
+++ b/Ergo/Solver/Built-Ins/Reflection/Compare.cs
@@ -17,17 +17,17 @@ public sealed class Compare : SolverBuiltIn
             if (!arguments[0].Matches<int>(out var result))
             {
                 scope.Throw(SolverError.ExpectedTermOfTypeAt, WellKnown.Types.Number, arguments[0].Explain());
-                yield return new(WellKnown.Literals.False);
+                yield return False();
                 yield break;
             }
 
             if (result.Equals(cmp))
             {
-                yield return new(WellKnown.Literals.True);
+                yield return True();
             }
             else
             {
-                yield return new(WellKnown.Literals.False);
+                yield return False();
             }
 
             yield break;

--- a/Ergo/Solver/Built-Ins/Reflection/Compare.cs
+++ b/Ergo/Solver/Built-Ins/Reflection/Compare.cs
@@ -9,7 +9,7 @@ public sealed class Compare : SolverBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] arguments)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> arguments)
     {
         var cmp = arguments[1].CompareTo(arguments[2]);
         if (arguments[0].IsGround)

--- a/Ergo/Solver/Built-Ins/Reflection/CopyTerm.cs
+++ b/Ergo/Solver/Built-Ins/Reflection/CopyTerm.cs
@@ -7,7 +7,7 @@ public sealed class CopyTerm : SolverBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] args)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> args)
     {
         var copy = args[0].Instantiate(scope.InstantiationContext);
         if (!LanguageExtensions.Unify(args[1], copy).TryGetValue(out var subs))

--- a/Ergo/Solver/Built-Ins/Reflection/Explain.cs
+++ b/Ergo/Solver/Built-Ins/Reflection/Explain.cs
@@ -12,15 +12,15 @@ public sealed class Explain : SolverBuiltIn
         var expl = new Atom(arguments[0].AsQuoted(false).Explain(), false);
         if (!arguments[1].IsGround)
         {
-            yield return new(WellKnown.Literals.True, new Substitution(arguments[1], expl));
+            yield return True(new Substitution(arguments[1], expl));
         }
         else if (LanguageExtensions.Unify(arguments[1], expl).TryGetValue(out var subs))
         {
-            yield return new(WellKnown.Literals.True, subs);
+            yield return True(subs);
         }
         else
         {
-            yield return new(WellKnown.Literals.False);
+            yield return False();
         }
     }
 }

--- a/Ergo/Solver/Built-Ins/Reflection/Explain.cs
+++ b/Ergo/Solver/Built-Ins/Reflection/Explain.cs
@@ -7,7 +7,7 @@ public sealed class Explain : SolverBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] arguments)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> arguments)
     {
         var expl = new Atom(arguments[0].AsQuoted(false).Explain(), false);
         if (!arguments[1].IsGround)

--- a/Ergo/Solver/Built-Ins/Reflection/Ground.cs
+++ b/Ergo/Solver/Built-Ins/Reflection/Ground.cs
@@ -7,7 +7,7 @@ public sealed class Ground : SolverBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] arguments)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> arguments)
     {
         yield return Bool(arguments[0].IsGround);
     }

--- a/Ergo/Solver/Built-Ins/Reflection/Ground.cs
+++ b/Ergo/Solver/Built-Ins/Reflection/Ground.cs
@@ -9,6 +9,6 @@ public sealed class Ground : SolverBuiltIn
 
     public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] arguments)
     {
-        yield return new(new Atom(arguments[0].IsGround));
+        yield return Bool(arguments[0].IsGround);
     }
 }

--- a/Ergo/Solver/Built-Ins/Reflection/Nonvar.cs
+++ b/Ergo/Solver/Built-Ins/Reflection/Nonvar.cs
@@ -7,7 +7,7 @@ public sealed class Nonvar : SolverBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] arguments)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> arguments)
     {
         yield return Bool(arguments[0] is not Variable);
     }

--- a/Ergo/Solver/Built-Ins/Reflection/Nonvar.cs
+++ b/Ergo/Solver/Built-Ins/Reflection/Nonvar.cs
@@ -9,6 +9,6 @@ public sealed class Nonvar : SolverBuiltIn
 
     public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] arguments)
     {
-        yield return new(new Atom(arguments[0] is not Variable));
+        yield return Bool(arguments[0] is not Variable);
     }
 }

--- a/Ergo/Solver/Built-Ins/Reflection/Number.cs
+++ b/Ergo/Solver/Built-Ins/Reflection/Number.cs
@@ -9,7 +9,7 @@ public sealed class Number : SolverBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] arguments)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> arguments)
     {
         yield return Bool(arguments[0] is Atom { Value: EDecimal _ });
     }

--- a/Ergo/Solver/Built-Ins/Reflection/Number.cs
+++ b/Ergo/Solver/Built-Ins/Reflection/Number.cs
@@ -11,6 +11,6 @@ public sealed class Number : SolverBuiltIn
 
     public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] arguments)
     {
-        yield return new(new Atom(arguments[0] is Atom { Value: EDecimal _ }));
+        yield return Bool(arguments[0] is Atom { Value: EDecimal _ });
     }
 }

--- a/Ergo/Solver/Built-Ins/Reflection/NumberVars.cs
+++ b/Ergo/Solver/Built-Ins/Reflection/NumberVars.cs
@@ -9,7 +9,7 @@ public sealed class NumberVars : SolverBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] args)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> args)
     {
         var allSubs = new SubstitutionMap();
         var (start, end) = (0, 0);

--- a/Ergo/Solver/Built-Ins/Reflection/SequenceType.cs
+++ b/Ergo/Solver/Built-Ins/Reflection/SequenceType.cs
@@ -8,7 +8,7 @@ public sealed class SequenceType : SolverBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] arguments)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> arguments)
     {
         var (type, seq) = (arguments[1], arguments[0]);
         if (seq is Variable)

--- a/Ergo/Solver/Built-Ins/Reflection/SequenceType.cs
+++ b/Ergo/Solver/Built-Ins/Reflection/SequenceType.cs
@@ -21,7 +21,7 @@ public sealed class SequenceType : SolverBuiltIn
         {
             if (LanguageExtensions.Unify(type, new Atom("list")).TryGetValue(out var subs))
             {
-                yield return new(WellKnown.Literals.True, subs);
+                yield return True(subs);
                 yield break;
             }
         }
@@ -30,7 +30,7 @@ public sealed class SequenceType : SolverBuiltIn
         {
             if (LanguageExtensions.Unify(type, new Atom("comma_list")).TryGetValue(out var subs))
             {
-                yield return new(WellKnown.Literals.True, subs);
+                yield return True(subs);
                 yield break;
             }
         }
@@ -39,11 +39,11 @@ public sealed class SequenceType : SolverBuiltIn
         {
             if (LanguageExtensions.Unify(type, new Atom("bracy_list")).TryGetValue(out var subs))
             {
-                yield return new(WellKnown.Literals.True, subs);
+                yield return True(subs);
                 yield break;
             }
         }
 
-        yield return new(WellKnown.Literals.False);
+        yield return False();
     }
 }

--- a/Ergo/Solver/Built-Ins/Reflection/Term.cs
+++ b/Ergo/Solver/Built-Ins/Reflection/Term.cs
@@ -20,11 +20,11 @@ public sealed class Term : SolverBuiltIn
                 || !LanguageExtensions.Unify(args, new List((new[] { tag }).Append(new List(dict.KeyValuePairs, default, dict.Scope)), default, dict.Scope))
                         .TryGetValue(out var listSubs))
                 {
-                    yield return new(WellKnown.Literals.False);
+                    yield return False();
                     yield break;
                 }
 
-                yield return new(WellKnown.Literals.True, SubstitutionMap.MergeRef(funSubs, listSubs));
+                yield return True(SubstitutionMap.MergeRef(funSubs, listSubs));
                 yield break;
             }
 
@@ -33,11 +33,11 @@ public sealed class Term : SolverBuiltIn
                 if (!LanguageExtensions.Unify(functorArg, complex.Functor).TryGetValue(out var funSubs)
                 || !LanguageExtensions.Unify(args, new List(complex.Arguments, default, complex.Scope)).TryGetValue(out var listSubs))
                 {
-                    yield return new(WellKnown.Literals.False);
+                    yield return False();
                     yield break;
                 }
 
-                yield return new(WellKnown.Literals.True, SubstitutionMap.MergeRef(funSubs, listSubs));
+                yield return True(SubstitutionMap.MergeRef(funSubs, listSubs));
                 yield break;
             }
 
@@ -46,11 +46,11 @@ public sealed class Term : SolverBuiltIn
                 if (!LanguageExtensions.Unify(functorArg, atom).TryGetValue(out var funSubs)
                 || !LanguageExtensions.Unify(args, WellKnown.Literals.EmptyList).TryGetValue(out var listSubs))
                 {
-                    yield return new(WellKnown.Literals.False);
+                    yield return False();
                     yield break;
                 }
 
-                yield return new(WellKnown.Literals.True, SubstitutionMap.MergeRef(funSubs, listSubs));
+                yield return True(SubstitutionMap.MergeRef(funSubs, listSubs));
                 yield break;
             }
         }
@@ -78,21 +78,21 @@ public sealed class Term : SolverBuiltIn
             if (!LanguageExtensions.Unify(termArg, functor).TryGetValue(out var subs)
             || !LanguageExtensions.Unify(args, WellKnown.Literals.EmptyList).TryGetValue(out var argsSubs))
             {
-                yield return new(WellKnown.Literals.False);
+                yield return False();
                 yield break;
             }
 
-            yield return new(WellKnown.Literals.True, SubstitutionMap.MergeRef(argsSubs, subs));
+            yield return True(SubstitutionMap.MergeRef(argsSubs, subs));
         }
         else
         {
             if (!LanguageExtensions.Unify(termArg, new Complex(functor, argsList.Contents.ToArray())).TryGetValue(out var subs))
             {
-                yield return new(WellKnown.Literals.False);
+                yield return False();
                 yield break;
             }
 
-            yield return new(WellKnown.Literals.True, subs);
+            yield return True(subs);
         }
     }
 }

--- a/Ergo/Solver/Built-Ins/Reflection/Term.cs
+++ b/Ergo/Solver/Built-Ins/Reflection/Term.cs
@@ -8,7 +8,7 @@ public sealed class Term : SolverBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] arguments)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> arguments)
     {
         var (functorArg, args, termArg) = (arguments[0], arguments[1], arguments[2]);
         if (termArg is not Variable)

--- a/Ergo/Solver/Built-Ins/Reflection/TermType.cs
+++ b/Ergo/Solver/Built-Ins/Reflection/TermType.cs
@@ -7,7 +7,7 @@ public sealed class TermType : SolverBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] arguments)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> arguments)
     {
         var type = arguments[0] switch
         {

--- a/Ergo/Solver/Built-Ins/Reflection/TermType.cs
+++ b/Ergo/Solver/Built-Ins/Reflection/TermType.cs
@@ -19,15 +19,15 @@ public sealed class TermType : SolverBuiltIn
 
         if (!arguments[1].IsGround)
         {
-            yield return new(WellKnown.Literals.True, new Substitution(arguments[1], type));
+            yield return True(new Substitution(arguments[1], type));
         }
         else if (LanguageExtensions.Unify(arguments[1], type).TryGetValue(out var subs))
         {
-            yield return new(WellKnown.Literals.True, subs);
+            yield return True(subs);
         }
         else
         {
-            yield return new(WellKnown.Literals.False);
+            yield return False();
         }
     }
 }

--- a/Ergo/Solver/Built-Ins/Reflection/Variant.cs
+++ b/Ergo/Solver/Built-Ins/Reflection/Variant.cs
@@ -7,7 +7,7 @@ public sealed class Variant : SolverBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] args)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> args)
     {
         if (args[0].IsVariantOf(args[1]))
             yield return True(new SubstitutionMap());

--- a/Ergo/Solver/Built-Ins/Set/IsSet.cs
+++ b/Ergo/Solver/Built-Ins/Set/IsSet.cs
@@ -8,7 +8,7 @@ public sealed class IsSet : SolverBuiltIn
 
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext solver, SolverScope scope, ITerm[] args)
+    public override IEnumerable<Evaluation> Apply(SolverContext solver, SolverScope scope, ImmutableArray<ITerm> args)
     {
         if (args[0] is Set)
             yield return True();

--- a/Ergo/Solver/Built-Ins/Set/Union.cs
+++ b/Ergo/Solver/Built-Ins/Set/Union.cs
@@ -8,7 +8,7 @@ public sealed class Union : SolverBuiltIn
 
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext solver, SolverScope scope, ITerm[] args)
+    public override IEnumerable<Evaluation> Apply(SolverContext solver, SolverScope scope, ImmutableArray<ITerm> args)
     {
         if (args[0] is Set s1)
         {

--- a/Ergo/Solver/Built-Ins/String/FormatString.cs
+++ b/Ergo/Solver/Built-Ins/String/FormatString.cs
@@ -11,7 +11,7 @@ public sealed class FormatString : SolverBuiltIn
         : base("", new("str_fmt"), Maybe<int>.Some(3), WellKnown.Modules.String)
     {
     }
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] arguments)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> arguments)
     {
         var (format, args, result) = (arguments[0], arguments[1], arguments[2]);
         if (!format.Matches<string>(out var formatStr))

--- a/Ergo/Solver/Built-Ins/String/FormatString.cs
+++ b/Ergo/Solver/Built-Ins/String/FormatString.cs
@@ -71,15 +71,15 @@ public sealed class FormatString : SolverBuiltIn
 
         if (result.IsGround && formatStr.Equals(resultStrRaw))
         {
-            yield return new(WellKnown.Literals.True, varSubs);
+            yield return True(varSubs);
         }
         else if (!result.IsGround)
         {
-            yield return new(WellKnown.Literals.True, new Substitution(result, new Atom(formatStr)));
+            yield return True(new Substitution(result, new Atom(formatStr)));
         }
         else
         {
-            yield return new(WellKnown.Literals.False);
+            yield return False();
         }
     }
 }

--- a/Ergo/Solver/Built-Ins/Tabling/Tabled.cs
+++ b/Ergo/Solver/Built-Ins/Tabling/Tabled.cs
@@ -9,7 +9,7 @@ public sealed class Tabled : SolverBuiltIn
     {
     }
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] args)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> args)
     {
         /* tabled/1 overrides the regular SLD resolution with SLDT resolution.
          * Predicates tagged by the 'table' directive are rewritten as follows:

--- a/Ergo/Solver/Built-Ins/_Shared/BuiltIn.cs
+++ b/Ergo/Solver/Built-Ins/_Shared/BuiltIn.cs
@@ -5,7 +5,7 @@ public abstract class SolverBuiltIn
     public readonly Signature Signature;
     public readonly string Documentation;
 
-    public Predicate GetStub(ITerm[] arguments)
+    public Predicate GetStub(ImmutableArray<ITerm> arguments)
     {
         var module = Signature.Module.GetOr(WellKnown.Modules.Stdlib);
         var head = ((ITerm)new Complex(Signature.Functor, arguments)).Qualified(module);
@@ -23,7 +23,7 @@ public abstract class SolverBuiltIn
     protected Evaluation True(SubstitutionMap subs) => new(true, subs);
     protected Evaluation True(Substitution sub) => new(true, sub);
 
-    public abstract IEnumerable<Evaluation> Apply(SolverContext solver, SolverScope scope, ITerm[] arguments);
+    public abstract IEnumerable<Evaluation> Apply(SolverContext solver, SolverScope scope, ImmutableArray<ITerm> arguments);
 
     public SolverBuiltIn(string documentation, Atom functor, Maybe<int> arity, Atom module)
     {

--- a/Ergo/Solver/Built-Ins/_Shared/BuiltIn.cs
+++ b/Ergo/Solver/Built-Ins/_Shared/BuiltIn.cs
@@ -17,11 +17,11 @@ public abstract class SolverBuiltIn
         scope.InterpreterScope.ExceptionHandler.Throw(new SolverException(error, scope, args));
         return False();
     }
-    protected Evaluation Bool(bool b) => b ? True() : False();
-    protected Evaluation False() => new(WellKnown.Literals.False);
-    protected Evaluation True() => new(WellKnown.Literals.True);
-    protected Evaluation True(SubstitutionMap subs) => new(WellKnown.Literals.True, subs);
-    protected Evaluation True(Substitution sub) => new(WellKnown.Literals.True, sub);
+    protected Evaluation Bool(bool b) => new(b);
+    protected Evaluation False() => new(false);
+    protected Evaluation True() => new(true);
+    protected Evaluation True(SubstitutionMap subs) => new(true, subs);
+    protected Evaluation True(Substitution sub) => new(true, sub);
 
     public abstract IEnumerable<Evaluation> Apply(SolverContext solver, SolverScope scope, ITerm[] arguments);
 

--- a/Ergo/Solver/Built-Ins/_Shared/DynamicPredicateBuiltIn.cs
+++ b/Ergo/Solver/Built-Ins/_Shared/DynamicPredicateBuiltIn.cs
@@ -47,19 +47,19 @@ public abstract class DynamicPredicateBuiltIn : SolverBuiltIn
         foreach (var match in solver.KnowledgeBase.GetMatches(new("R"), term, desugar: true)
             .AsEnumerable().SelectMany(x => x))
         {
-            if (!match.Rhs.IsDynamic)
+            if (!match.Predicate.IsDynamic)
             {
                 scope.Throw(SolverError.CannotRetractStaticPredicate, scope, sig.Explain());
                 return false;
             }
 
-            if (scope.InterpreterScope.Entry != match.Rhs.DeclaringModule)
+            if (scope.InterpreterScope.Entry != match.Predicate.DeclaringModule)
             {
-                scope.Throw(SolverError.CannotRetractImportedPredicate, scope, sig.Explain(), scope.InterpreterScope.Entry.Explain(), match.Rhs.DeclaringModule.Explain());
+                scope.Throw(SolverError.CannotRetractImportedPredicate, scope, sig.Explain(), scope.InterpreterScope.Entry.Explain(), match.Predicate.DeclaringModule.Explain());
                 return false;
             }
 
-            toRemove.Add(match.Rhs.Head);
+            toRemove.Add(match.Predicate.Head);
 
             if (!all)
                 break;

--- a/Ergo/Solver/Built-Ins/_Shared/Evaluation.cs
+++ b/Ergo/Solver/Built-Ins/_Shared/Evaluation.cs
@@ -2,15 +2,15 @@
 
 public readonly struct Evaluation
 {
-    public readonly ITerm Result;
+    public readonly bool Result;
     public readonly SubstitutionMap Substitutions { get; }
 
-    public Evaluation(ITerm result, SubstitutionMap subs = null)
+    public Evaluation(bool result, SubstitutionMap subs = null)
     {
         Result = result;
         Substitutions = subs ?? new();
     }
-    public Evaluation(ITerm result, Substitution sub)
+    public Evaluation(bool result, Substitution sub)
     {
         Result = result;
         Substitutions = new(new[] { sub });

--- a/Ergo/Solver/Built-Ins/_Shared/SolutionAggregationBuiltIn.cs
+++ b/Ergo/Solver/Built-Ins/_Shared/SolutionAggregationBuiltIn.cs
@@ -7,7 +7,7 @@ public abstract class SolutionAggregationBuiltIn : SolverBuiltIn
     {
     }
 
-    protected IEnumerable<(List ArgVars, List ListTemplate, List ListVars)> AggregateSolutions(ErgoSolver solver, SolverScope scope, ITerm[] args)
+    protected IEnumerable<(List ArgVars, List ListTemplate, List ListVars)> AggregateSolutions(ErgoSolver solver, SolverScope scope, ImmutableArray<ITerm> args)
     {
         var (template, goal, instances) = (args[0], args[1], args[2]);
         scope = scope.WithDepth(scope.Depth + 1)

--- a/Ergo/Solver/Built-Ins/_Shared/WriteBuiltIn.cs
+++ b/Ergo/Solver/Built-Ins/_Shared/WriteBuiltIn.cs
@@ -32,7 +32,7 @@ public abstract class WriteBuiltIn : SolverBuiltIn
 
     protected virtual string Explain(ITerm arg) => AsQuoted(arg, Quoted).Explain(Canonical);
 
-    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ITerm[] args)
+    public override IEnumerable<Evaluation> Apply(SolverContext context, SolverScope scope, ImmutableArray<ITerm> args)
     {
         foreach (var arg in args)
         {

--- a/Ergo/Solver/Built-Ins/_Shared/WriteBuiltIn.cs
+++ b/Ergo/Solver/Built-Ins/_Shared/WriteBuiltIn.cs
@@ -54,6 +54,6 @@ public abstract class WriteBuiltIn : SolverBuiltIn
             context.Solver.Out.Flush();
         }
     ret:
-        yield return new(WellKnown.Literals.True);
+        yield return True();
     }
 }

--- a/Ergo/Solver/ErgoSolver.cs
+++ b/Ergo/Solver/ErgoSolver.cs
@@ -191,7 +191,7 @@ public partial class ErgoSolver : IDisposable
         foreach (var exp in queryExpansions)
         {
             using var ctx = SolverContext.Create(this, scope.InterpreterScope);
-            var newPred = Predicate.Substitute(exp.Rhs, exp.Substitutions.Select(x => x.Inverted()));
+            var newPred = Predicate.Substitute(exp.Predicate, exp.Substitutions.Select(x => x.Inverted()));
             foreach (var s in ctx.Solve(new(newPred.Body), scope.WithCallee(newPred), ct: ct))
             {
                 yield return s;

--- a/Ergo/Solver/SolverContext.cs
+++ b/Ergo/Solver/SolverContext.cs
@@ -184,7 +184,7 @@ public sealed class SolverContext : IDisposable
             yield break;
         }
 
-        if (goal is Atom { Value: false })
+        if (goal is Variable || goal is Atom { Value: false })
         {
             yield break;
         }

--- a/Ergo/Solver/SolverContext.cs
+++ b/Ergo/Solver/SolverContext.cs
@@ -1,7 +1,6 @@
 ﻿using Ergo.Debugger;
 using Ergo.Events.Solver;
 using Ergo.Interpreter;
-using Ergo.Solver.BuiltIns;
 using System.Collections.Concurrent;
 using System.Runtime.ExceptionServices;
 
@@ -68,53 +67,6 @@ public sealed class SolverContext : IDisposable
         return root;
     }
 
-    /// <summary>
-    /// Attempts to resolve 'goal' as a built-in call, and evaluates its result. On failure evaluates 'goal' as-is.
-    /// </summary>
-    public IEnumerable<Evaluation> ResolveGoal(ITerm goal, SolverScope scope, CancellationToken ct = default)
-    {
-        var any = false;
-        var sig = goal.GetSignature();
-        if (!goal.IsQualified)
-        {
-            // Try resolving the built-in's module automatically
-            foreach (var key in scope.InterpreterScope.VisibleBuiltInsKeys)
-            {
-                if (!key.Module.TryGetValue(out var module))
-                    continue;
-                var withoutModule = key.WithModule(default);
-                if (withoutModule.Equals(sig))
-                {
-                    goal = goal.Qualified(module);
-                    sig = key;
-                    break;
-                }
-            }
-        }
-
-        if (scope.InterpreterScope.VisibleBuiltIns.TryGetValue(sig, out var builtIn))
-        {
-            goal.GetQualification(out goal);
-            var args = goal.GetArguments();
-            scope.Trace(SolverTraceType.BuiltInResolution, goal);
-            if (builtIn.Signature.Arity.TryGetValue(out var arity) && args.Length != arity)
-            {
-                scope.Throw(SolverError.UndefinedPredicate, sig.WithArity(args.Length).Explain());
-                yield break;
-            }
-
-            foreach (var eval in builtIn.Apply(this, scope, args.ToArray()))
-            {
-                _debuggerSignal.WaitOne();
-                yield return eval;
-                any = true;
-            }
-        }
-
-        if (!any)
-            yield return new(true);
-    }
-
     public IEnumerable<Solution> Solve(Query goal, SolverScope scope, CancellationToken ct = default)
     {
         scope.InterpreterScope.ExceptionHandler.Throwing += Cancel;
@@ -132,6 +84,11 @@ public sealed class SolverContext : IDisposable
         scope.InterpreterScope.ExceptionHandler.Throwing -= Cancel;
         scope.InterpreterScope.ExceptionHandler.Caught -= Cancel;
         void Cancel(ExceptionDispatchInfo _) => _exceptionCts.Cancel(false);
+    }
+
+    public void Cut()
+    {
+        _choicePointCts.Cancel(false);
     }
 
 
@@ -221,6 +178,17 @@ public sealed class SolverContext : IDisposable
         if (goal.IsParenthesized)
             scope = scope.WithChoicePoint();
 
+        if (goal is Atom { Value: true })
+        {
+            yield return new(scope, new());
+            yield break;
+        }
+
+        if (goal is Atom { Value: false })
+        {
+            yield break;
+        }
+
         // Treat comma-expression complex ITerms as proper expressions
         if (goal is NTuple goalList)
         {
@@ -236,89 +204,76 @@ public sealed class SolverContext : IDisposable
             }
             yield break;
         }
-
-        // If goal resolves to a builtin, it is called on the spot and its solutions enumerated (usually just ⊤ or ⊥, plus a list of substitutions)
-        // If goal does not resolve to a builtin it is returned as-is, and it is then matched against the knowledge base.
-        foreach (var resolvedGoal in ResolveGoal(goal, scope, ct: ct))
+        // Attempts qualifying a goal with a module, then finds matches in the knowledge base
+        var noMatches = true;
+        var matches = ErgoSolver.GetImplicitGoalQualifications(goal, scope)
+            .Select(x => Solver.KnowledgeBase.GetMatches(scope.InstantiationContext, x, desugar: false))
+            .Where(x => x.TryGetValue(out _) && !(noMatches = false))
+            .Take(1)
+            .SelectMany(m => m.AsEnumerable().SelectMany(x => x));
+        foreach (var m in matches)
         {
-            _debuggerSignal.WaitOne();
-            if (!resolvedGoal.Result)
+            // Create a new scope and context for this procedure call, essentially creating a choice point
+            var innerScope = scope
+                .WithDepth(scope.Depth + 1)
+                .WithModule(m.Predicate.DeclaringModule)
+                .WithCallee(m.Predicate)
+                .WithCaller(scope.Callee)
+                .WithChoicePoint();
+            scope.Trace(SolverTraceType.Call, m.Goal);
+            if (m.Predicate.BuiltIn.TryGetValue(out var builtIn))
             {
-                scope.Trace(SolverTraceType.BuiltInResolution, WellKnown.Literals.False);
-                yield break;
-            }
-
-            if (resolvedGoal.Result.Equals(WellKnown.Literals.True))
-            {
-                yield return new(scope, resolvedGoal.Substitutions);
-                if (goal.Equals(WellKnown.Literals.Cut))
-                    _choicePointCts.Cancel(false);
+                foreach (var eval in builtIn.Apply(this, scope, goal.GetArguments()))
+                {
+                    if (!eval.Result)
+                        yield break;
+                    else
+                        yield return new(scope, eval.Substitutions);
+                }
                 continue;
             }
-
-            // Attempts qualifying a goal with a module, then finds matches in the knowledge base
-            var noMatches = true;
-            var matches = ErgoSolver.GetImplicitGoalQualifications(goal, scope)
-                .Select(x => Solver.KnowledgeBase.GetMatches(scope.InstantiationContext, x, desugar: false))
-                .Where(x => x.TryGetValue(out _) && !(noMatches = false))
-                .Take(1)
-                .SelectMany(m => m.AsEnumerable().SelectMany(x => x));
-            foreach (var m in matches)
-            {
-                // Create a new scope and context for this procedure call, essentially creating a choice point
-                var innerScope = scope
-                    .WithDepth(scope.Depth + 1)
-                    .WithModule(m.Rhs.DeclaringModule)
-                    .WithCallee(m.Rhs)
-                    .WithCaller(scope.Callee)
-                    .WithChoicePoint();
-                var callerVars = scope.Callee.Body.Variables;
-                var calleeVars = m.Rhs.Body.Variables;
 #if !ERGO_SOLVER_DISABLE_TCO
-                if (m.Rhs.IsTailRecursive)
-                {
-                    // PROBLEM: This branch should only be entered iff the predicate is known to be determinate at this point
-                    // https://sicstus.sics.se/sicstus/docs/3.12.8/html/sicstus/Last-Clause-Determinacy-Detection.html
-                    // https://sicstus.sics.se/sicstus/docs/3.12.8/html/sicstus/What-is-Detected.html#What-is-Detected
-                    // https://www.mercurylang.org/information/doc-latest/mercury_ref/Determinism.html#Determinism-categories
-                    // https://www.metalevel.at/prolog/fun
-                    // Yield a "fake" solution to the caller, which will then use it to perform TCO
-                    scope.Trace(SolverTraceType.TailCallOptimization, m.Lhs);
-                    _debuggerSignal.WaitOne();
-                    yield return new(innerScope, SubstitutionMap.MergeRef(m.Substitutions, resolvedGoal.Substitutions));
-                    continue;
-                }
-#endif
-                using var innerCtx = CreateChild();
-                scope.Trace(SolverTraceType.Call, m.Lhs);
-                foreach (var s in innerCtx.SolveQuery(m.Rhs.Body, innerScope, ct: ct))
-                {
-                    scope.Trace(SolverTraceType.Exit, m.Rhs.Head.Substitute(s.Substitutions));
-                    var innerSubs = SubstitutionMap.MergeRef(m.Substitutions, resolvedGoal.Substitutions);
-                    yield return s.PrependSubstitutions(innerSubs);
-                }
-                if (innerCtx._choicePointCts.IsCancellationRequested)
-                    break;
-                // Backtrack
-                scope.Trace(SolverTraceType.Backtrack, m.Lhs);
-                _debuggerSignal.WaitOne();
-            }
-            if (noMatches)
+            if (m.Predicate.IsTailRecursive)
             {
-                var signature = goal.GetSignature();
-                if (Solver.KnowledgeBase.Any(p => p.Head.GetSignature().Equals(signature)))
-                    continue;
-                var dyn = scope.InterpreterScope.Modules.Values
-                    .SelectMany(m => m.DynamicPredicates)
-                    .SelectMany(p => new[] { p, p.WithModule(default) })
-                    .ToHashSet();
-                if (dyn.Contains(signature))
-                    continue;
-                if (Solver.Flags.HasFlag(SolverFlags.ThrowOnPredicateNotFound))
-                    scope.Throw(SolverError.UndefinedPredicate, signature.Explain());
-                _choicePointCts.Cancel(false);
-                yield break;
+                // PROBLEM: This branch should only be entered iff the predicate is known to be determinate at this point
+                // https://sicstus.sics.se/sicstus/docs/3.12.8/html/sicstus/Last-Clause-Determinacy-Detection.html
+                // https://sicstus.sics.se/sicstus/docs/3.12.8/html/sicstus/What-is-Detected.html#What-is-Detected
+                // https://www.mercurylang.org/information/doc-latest/mercury_ref/Determinism.html#Determinism-categories
+                // https://www.metalevel.at/prolog/fun
+                // Yield a "fake" solution to the caller, which will then use it to perform TCO
+                scope.Trace(SolverTraceType.TailCallOptimization, m.Goal);
+                _debuggerSignal.WaitOne();
+                yield return new(innerScope, m.Substitutions);
+                continue;
             }
+#endif
+            using var innerCtx = CreateChild();
+            foreach (var s in innerCtx.SolveQuery(m.Predicate.Body, innerScope, ct: ct))
+            {
+                scope.Trace(SolverTraceType.Exit, m.Predicate.Head.Substitute(s.Substitutions));
+                yield return s.PrependSubstitutions(m.Substitutions);
+            }
+            if (innerCtx._choicePointCts.IsCancellationRequested)
+                break;
+            // Backtrack
+            scope.Trace(SolverTraceType.Backtrack, m.Goal);
+            _debuggerSignal.WaitOne();
+        }
+        if (noMatches)
+        {
+            var signature = goal.GetSignature();
+            if (Solver.KnowledgeBase.Any(p => p.Head.GetSignature().Equals(signature)))
+                yield break;
+            var dyn = scope.InterpreterScope.Modules.Values
+                .SelectMany(m => m.DynamicPredicates)
+                .SelectMany(p => new[] { p, p.WithModule(default) })
+                .ToHashSet();
+            if (dyn.Contains(signature))
+                yield break;
+            if (Solver.Flags.HasFlag(SolverFlags.ThrowOnPredicateNotFound))
+                scope.Throw(SolverError.UndefinedPredicate, signature.Explain());
+            _choicePointCts.Cancel(false);
+            yield break;
         }
     }
 

--- a/Ergo/ergo/stdlib/math/math.ergo
+++ b/Ergo/ergo/stdlib/math/math.ergo
@@ -46,17 +46,17 @@
 %: Assignment of A to the arithmetic evaluation of B.
 ':='(A, B) :- eval_is(A, B).
 %: Equivalence of the arithmetic evaluations of A and B.
-'=:='(A, B) :- eval(A) == eval(B).
+'=:='(A, B) :- eval(A, Ae), eval(B, Be), Ae == Be.
 %: Inequivalence of the arithmetic evaluations of A and B.
-'=\\='(A, B) :- eval(A) \== eval(B).
+'=\\='(A, B) :-eval(A, Ae), eval(B, Be), Ae \== Be.
 %: Arithmetic comparison (gt).
-'>'(A, B)  :- eval(A > B).
+'>'(A, B)  :- eval(A > B, true).
 %: Arithmetic comparison (lt).
-'<'(A, B)  :- eval(A < B).
+'<'(A, B)  :- eval(A < B, true).
 %: Arithmetic comparison (gte).
-'>='(A, B) :- eval(A >= B).
+'>='(A, B) :- eval(A >= B, true).
 %: Arithmetic comparison (lte).
-'<='(A, B) :- eval(A <= B).
+'<='(A, B) :- eval(A <= B, true).
 
 % HELPERS
 

--- a/Ergo/ergo/stdlib/math/math.ergo
+++ b/Ergo/ergo/stdlib/math/math.ergo
@@ -46,17 +46,17 @@
 %: Assignment of A to the arithmetic evaluation of B.
 ':='(A, B) :- eval_is(A, B).
 %: Equivalence of the arithmetic evaluations of A and B.
-'=:='(A, B) :- eval(A, Ae), eval(B, Be), Ae == Be.
+'=:='(A, B) :- eval(Ae, A), eval(Be, B), Ae == Be.
 %: Inequivalence of the arithmetic evaluations of A and B.
-'=\\='(A, B) :-eval(A, Ae), eval(B, Be), Ae \== Be.
+'=\\='(A, B) :-eval(Ae, A), eval(Be, B), Ae \== Be.
 %: Arithmetic comparison (gt).
-'>'(A, B)  :- eval(A > B, true).
+'>'(A, B)  :- eval(true, A > B).
 %: Arithmetic comparison (lt).
-'<'(A, B)  :- eval(A < B, true).
+'<'(A, B)  :- eval(true, A < B).
 %: Arithmetic comparison (gte).
-'>='(A, B) :- eval(A >= B, true).
+'>='(A, B) :- eval(true, A >= B).
 %: Arithmetic comparison (lte).
-'<='(A, B) :- eval(A <= B, true).
+'<='(A, B) :- eval(true, A <= B).
 
 % HELPERS
 

--- a/Ergo/ergo/stdlib/prologue/prologue.ergo
+++ b/Ergo/ergo/stdlib/prologue/prologue.ergo
@@ -16,7 +16,7 @@
 :- op(1000, xfy,  [':']).
 :- op(920, fx, ['*']).
 
-:- inline(['≠'/2, '¬'/1, '∨'/2, '∧'/2, '*'/1]).
+:- inline(['≠'/2, '¬'/1, '*'/1]).
 
 % OPERATOR IMPLEMENTATIONS
 
@@ -28,9 +28,6 @@ If -> Then :- If, !, Then.
 ';'(A, _B) :- A.
 %: Logical disjunction of A and B.
 ';'(_A, B) :- B.
-
-'∨'(A, B) :- A ; B.
-'∧'(A, B) :- A , B.
 
 %: Logical complement of A (negation).
 %: ⊤ iff A cannot be proven.

--- a/ErgoVSIX/ErgoLS/ergo/stdlib/dict.ergo
+++ b/ErgoVSIX/ErgoLS/ergo/stdlib/dict.ergo
@@ -7,8 +7,6 @@
 :- op(850, xfy, [with]).
 :- op(850, xfy, [without]).
 
-:- inline(['='/2]).
-
 %: Directly dereferences and evaluates a dictionary property
 :- expand([Val] >> (
 	% dict_deref_ needs to be qualified since it isn't exported. The macro will run in the context of another module!

--- a/ErgoVSIX/ErgoLS/ergo/stdlib/math.ergo
+++ b/ErgoVSIX/ErgoLS/ergo/stdlib/math.ergo
@@ -46,17 +46,17 @@
 %: Assignment of A to the arithmetic evaluation of B.
 ':='(A, B) :- eval_is(A, B).
 %: Equivalence of the arithmetic evaluations of A and B.
-'=:='(A, B) :- eval(A) == eval(B).
+'=:='(A, B) :- eval(A, Ae), eval(B, Be), Ae == Be.
 %: Inequivalence of the arithmetic evaluations of A and B.
-'=\\='(A, B) :- eval(A) \== eval(B).
+'=\\='(A, B) :-eval(A, Ae), eval(B, Be), Ae \== Be.
 %: Arithmetic comparison (gt).
-'>'(A, B)  :- eval(A > B).
+'>'(A, B)  :- eval(A > B, true).
 %: Arithmetic comparison (lt).
-'<'(A, B)  :- eval(A < B).
+'<'(A, B)  :- eval(A < B, true).
 %: Arithmetic comparison (gte).
-'>='(A, B) :- eval(A >= B).
+'>='(A, B) :- eval(A >= B, true).
 %: Arithmetic comparison (lte).
-'<='(A, B) :- eval(A <= B).
+'<='(A, B) :- eval(A <= B, true).
 
 % HELPERS
 

--- a/ErgoVSIX/ErgoLS/ergo/stdlib/math.ergo
+++ b/ErgoVSIX/ErgoLS/ergo/stdlib/math.ergo
@@ -46,17 +46,17 @@
 %: Assignment of A to the arithmetic evaluation of B.
 ':='(A, B) :- eval_is(A, B).
 %: Equivalence of the arithmetic evaluations of A and B.
-'=:='(A, B) :- eval(A, Ae), eval(B, Be), Ae == Be.
+'=:='(A, B) :- eval(Ae, A), eval(Be, B), Ae == Be.
 %: Inequivalence of the arithmetic evaluations of A and B.
-'=\\='(A, B) :-eval(A, Ae), eval(B, Be), Ae \== Be.
+'=\\='(A, B) :-eval(Ae, A), eval(Be, B), Ae \== Be.
 %: Arithmetic comparison (gt).
-'>'(A, B)  :- eval(A > B, true).
+'>'(A, B)  :- eval(true, A > B).
 %: Arithmetic comparison (lt).
-'<'(A, B)  :- eval(A < B, true).
+'<'(A, B)  :- eval(true, A < B).
 %: Arithmetic comparison (gte).
-'>='(A, B) :- eval(A >= B, true).
+'>='(A, B) :- eval(true, A >= B).
 %: Arithmetic comparison (lte).
-'<='(A, B) :- eval(A <= B, true).
+'<='(A, B) :- eval(true, A <= B).
 
 % HELPERS
 

--- a/ErgoVSIX/ErgoLS/ergo/stdlib/prologue.ergo
+++ b/ErgoVSIX/ErgoLS/ergo/stdlib/prologue.ergo
@@ -16,7 +16,7 @@
 :- op(1000, xfy,  [':']).
 :- op(920, fx, ['*']).
 
-:- inline(['≠'/2, '¬'/1, '∨'/2, '∧'/2, '*'/1, '='/2]).
+:- inline(['≠'/2, '¬'/1, '*'/1]).
 
 % OPERATOR IMPLEMENTATIONS
 
@@ -29,16 +29,13 @@ If -> Then :- If, !, Then.
 %: Logical disjunction of A and B.
 ';'(_A, B) :- B.
 
-'∨'(A, B) :- A ; B.
-'∧'(A, B) :- A , B.
-
 %: Logical complement of A (negation).
 %: ⊤ iff A cannot be proven.
 '¬'(A) :- not(A), !.
 %: Unification of A and B.
 '='(A, B) :- unify(A, B).
 %: Negation of the unification of A and B.
-'≠'(A, B) :- \+(A = B).
+'≠'(A, B) :- not(unify(A, B)).
 %: Used for declarative debugging; "comments out" the following statement.
 %: Note: this predicate is automatically inlined, which means that it effectively removes the statement from the goal list.
 *_. 


### PR DESCRIPTION
This is quite a big PR but it finally introduces an actual compiler that produces executable graphs. These graphs can be further optimized by performing some compile-time checks. The graph structure implicitly takes care of control flow, while the optimizations reduce the graph size as much as possible.

There's also an inlining process which runs before the compilation step. It can provide benefits in the interpreted case, and it also makes compilation faster.